### PR TITLE
[FIX] Correção versão do Pyhton para 3.10.13

### DIFF
--- a/16.1.Dockerfile
+++ b/16.1.Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11.5-slim-bullseye AS base
+FROM python:3.10.13-slim-bullseye AS base
  
 EXPOSE 8069 8072
 
@@ -64,7 +64,7 @@ RUN apt-get -qq update \
 
 WORKDIR /opt/odoo
 COPY bin/* /usr/local/bin/
-COPY lib/doodbalib /usr/local/lib/python3.11/site-packages/doodbalib
+COPY lib/doodbalib /usr/local/lib/python3.10/site-packages/doodbalib
 COPY build.d common/build.d
 COPY conf.d common/conf.d
 COPY entrypoint.d common/entrypoint.d
@@ -72,7 +72,7 @@ RUN mkdir -p auto/addons auto/geoip custom/src/private \
     && ln /usr/local/bin/direxec common/entrypoint \
     && ln /usr/local/bin/direxec common/build \
     && chmod -R a+rx common/entrypoint* common/build* /usr/local/bin \
-    && chmod -R a+rX /usr/local/lib/python3.11/site-packages/doodbalib \
+    && chmod -R a+rX /usr/local/lib/python3.10/site-packages/doodbalib \
     && cp -a /etc/GeoIP.conf /etc/GeoIP.conf.orig \
     && mv /etc/GeoIP.conf /opt/odoo/auto/geoip/GeoIP.conf \
     && ln -s /opt/odoo/auto/geoip/GeoIP.conf /etc/GeoIP.conf \

--- a/16.1.Dockerfile
+++ b/16.1.Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim-bullseye AS base
+FROM python:3.11.5-slim-bullseye AS base
  
 EXPOSE 8069 8072
 
@@ -64,7 +64,7 @@ RUN apt-get -qq update \
 
 WORKDIR /opt/odoo
 COPY bin/* /usr/local/bin/
-COPY lib/doodbalib /usr/local/lib/python3.9/site-packages/doodbalib
+COPY lib/doodbalib /usr/local/lib/python3.11/site-packages/doodbalib
 COPY build.d common/build.d
 COPY conf.d common/conf.d
 COPY entrypoint.d common/entrypoint.d
@@ -72,7 +72,7 @@ RUN mkdir -p auto/addons auto/geoip custom/src/private \
     && ln /usr/local/bin/direxec common/entrypoint \
     && ln /usr/local/bin/direxec common/build \
     && chmod -R a+rx common/entrypoint* common/build* /usr/local/bin \
-    && chmod -R a+rX /usr/local/lib/python3.9/site-packages/doodbalib \
+    && chmod -R a+rX /usr/local/lib/python3.11/site-packages/doodbalib \
     && cp -a /etc/GeoIP.conf /etc/GeoIP.conf.orig \
     && mv /etc/GeoIP.conf /opt/odoo/auto/geoip/GeoIP.conf \
     && ln -s /opt/odoo/auto/geoip/GeoIP.conf /etc/GeoIP.conf \


### PR DESCRIPTION
Haviamos alterado a imagem pra python 3.9 pois o Annotatted foi adicionado na v3.9, mas existem alguns operadores no código da fastapi do odoo que foram introduzidos no Python 3.10 aparentemente https://github.com/tiangolo/typer/issues/371.

Para não travar o andamento das tasks, deixei a imagem apontando para o fork que realizei.